### PR TITLE
Star ratings loaded via turbolinks

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -51,5 +51,6 @@ window.updateProgress = function () {
 };
 
 document.addEventListener("turbolinks:load", () => {
-  popup_message()
+  popup_message();
+  $(document).on("turbolinks:load", initStarRating);
 });


### PR DESCRIPTION
This ensures the rating stars are loaded in the Add Review modal.